### PR TITLE
Allow reverse proxy subpaths

### DIFF
--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -25,5 +25,6 @@ module.exports = {
       entry: 'src/main.js',
       title: 'DailyTxT'
     }
-  }
+  },
+  publicPath: ''
 }


### PR DESCRIPTION
Really small fix that simply allows reverse proxy configurations to work correctly if the application is configured to a subpath.