### PR TITLE
Shrink docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,14 @@
 FROM node:15.5.0-alpine3.10 as build-vue
 WORKDIR /app
 ENV PATH /app/node_modules/.bin:$PATH
-COPY ./client/package*.json ./
-COPY ./client/.npmrc ./
+COPY ./client/package*.json ./client/.npmrc ./
 RUN npm config set update-notifier false && \
-    npm set registry https://registry.npmjs.org && \
     npm install
 COPY ./client .
 RUN npm run build
 
-# production
-FROM nginx:stable-alpine as production
+# python packages
+FROM python:3-alpine as builder
 WORKDIR /app
 RUN apk update && apk add --no-cache python3 && \
     python3 -m ensurepip && \
@@ -20,12 +18,17 @@ RUN apk update && apk add --no-cache python3 && \
     if [ ! -e /usr/bin/pip ]; then ln -s pip3 /usr/bin/pip ; fi && \
     if [[ ! -e /usr/bin/python ]]; then ln -sf /usr/bin/python3 /usr/bin/python; fi && \
     rm -r /root/.cache
-COPY --from=build-vue /app/dist /usr/share/nginx/html
-COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
 COPY ./server/requirements.txt ./
 RUN apk update && apk add --no-cache gcc musl-dev libressl-dev libffi-dev python3-dev && \
-    pip install -r requirements.txt && \
-    pip install gunicorn
+    pip install --user -r requirements.txt
+
+# production
+FROM nginx:stable-alpine as production
+WORKDIR /app
+COPY --from=build-vue /app/dist /usr/share/nginx/html
+COPY ./nginx/default.conf /etc/nginx/conf.d/default.conf
+COPY --from=builder /root/.local/ /usr/local/
+RUN apk update && apk add --no-cache py3-gunicorn
 COPY ./server .
 CMD gunicorn -b 0.0.0.0:5000 'dailytxt.application:create_app()' --daemon && \
     sed -i -e 's/$PORT/'"$PORT"'/g' /etc/nginx/conf.d/default.conf && \

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1798,9 +1798,9 @@
           }
         },
         "chalk": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1865,9 +1865,9 @@
           "optional": true
         },
         "loader-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-          "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+          "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1968,9 +1968,9 @@
           }
         },
         "vue-loader-v16": {
-          "version": "npm:vue-loader@16.1.2",
-          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.1.2.tgz",
-          "integrity": "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q==",
+          "version": "npm:vue-loader@16.8.3",
+          "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-16.8.3.tgz",
+          "integrity": "sha512-7vKN45IxsKxe5GcVCbc2qFU5aWzyiLrYJyUuMz4BQLKctCj/fmCa0w6fGiiQ2cLFetNcek1ppGJQDCup0c1hpA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -7662,11 +7662,6 @@
       "requires": {
         "object-visit": "^1.0.0"
       }
-    },
-    "material-design-icons": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/material-design-icons/-/material-design-icons-3.0.1.tgz",
-      "integrity": "sha1-mnHEh0chjrylHlGmbaaCA4zct78="
     },
     "material-design-icons-iconfont": {
       "version": "6.1.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,10 +10,8 @@
   "dependencies": {
     "animate.css": "^4.1.1",
     "axios": "^0.20.0",
-    "core-js": "^3.6.5",
     "jquery": "^3.5.1",
     "lodash": "^4.17.20",
-    "material-design-icons": "^3.0.1",
     "material-design-icons-iconfont": "^6.1.0",
     "materialize-css": "^1.0.0-rc.2",
     "register-service-worker": "^1.7.1",

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,51 @@
+# Define the user that will own and run the Nginx server
+user nginx;
+
+# Define the number of worker processes; recommended value is the number of
+# cores that are being used by your server
+worker_processes 1;
+
+# Define the location on the file system of the error log, plus the minimum
+# severity to log messages for
+error_log /var/log/nginx/error.log warn;
+
+# Define the file that will store the process ID of the main NGINX process
+pid /var/run/nginx.pid;
+
+# events block defines the parameters that affect connection processing.
+events {
+    # Define the maximum number of simultaneous connections that can be opened by a worker process
+    worker_connections 1024;
+}
+
+
+# http block defines the parameters for how NGINX should handle HTTP web traffic
+http {
+    # Include the file defining the list of file types that are supported by NGINX
+    include /etc/nginx/mime.types;
+
+    # Define the default file type that is returned to the user
+    default_type text/html;
+
+    # Define the format of log messages.
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    # Define the location of the log of access attempts to NGINX
+    access_log /var/log/nginx/access.log  main;
+
+    # Define the parameters to optimize the delivery of static content
+    sendfile on;
+    tcp_nopush on;
+    tcp_nodelay on;
+
+    # Define the timeout value for keep-alive connections with the client
+    keepalive_timeout 65;
+
+    # Define the usage of the gzip compression algorithm to reduce the amount of data to transmit
+    gzip on;
+
+    # Include additional parameters for virtual host(s)/server(s)
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -16,7 +16,7 @@ PyJWT == 1.7.1
 Werkzeug == 1.0.1
 
 # server/dailytxt/encryption.py: 1,2,3,4
-cryptography == 3.2.1
+cryptography == 35.0.0
 
 # server/dailytxt/logs.py: 3
 shortuuid == 1.0.1


### PR DESCRIPTION
By removing the unused npm module `material-design-icons` and moving most python package installation to another stage I managed to shrink the docker image size from ~340MB (127MB compressed) to ~94MB (34MB compressed).

For some reason I just couldn't get the gunicorn binary to copy over to the production image so theoretically it could be even smaller.